### PR TITLE
QA fixes for SiteImprove

### DIFF
--- a/pages/blog/posts/alpha-ca-gov-product-release-1.html
+++ b/pages/blog/posts/alpha-ca-gov-product-release-1.html
@@ -20,7 +20,7 @@ tags: news
 
 <p>As we’ve documented in our weekly “Done/doing” blogs, we’ve begun to build the proverbial plane, even as we’re approaching cruising altitude.</p>
 
-<p>To date, we have: configured our instances of GitHub, GSuite and Slack - tools not widely used in California state government. Gotten our cloud environment up and running ( thanks to a huge lift from <a href="https://twitter.com/CADeptTech">CDT</a>). Established initial <a href="https://handbook-cadotgov.readthedocs.io/en/latest/">workplace norms, ceremonies and workflows, design and operational principles</a>. Bootstrapped a web design architecture, developed and tested prototypes (including this new blog, which is open source and 100% accessible). Said 
+<p>To date, we have: configured our instances of GitHub, G Suite and Slack - tools not widely used in California state government. Gotten our cloud environment up and running ( thanks to a huge lift from <a href="https://twitter.com/CADeptTech">CDT</a>). Established initial <a href="https://handbook-cadotgov.readthedocs.io/en/latest/">workplace norms, ceremonies and workflows, design and operational principles</a>. Bootstrapped a web design architecture, developed and tested prototypes (including this new blog, which is open source and 100% accessible). Said 
 “<a href="https://twitter.com/CAdotGov/status/1204814757624086528">Hello California!</a>” Begun the ongoing process of gathering, researching and prioritizing <a href="https://twitter.com/CAdotGov/status/1202723639423950849">user needs</a>. Pushed out our <a href="https://twitter.com/CAdotGov/status/1207797255643766785">first user survey</a>. Gotten a sample SMS text up and running. Collaborated with, learned from, and greatly appreciated working with our state partners in our research, testing and fact checking.<p>
 
 <p>The ramp up was chaotic at times, like any start up. We’ve hit plenty of speed bumps along the way — and have plenty of learnings to share:</p>
@@ -43,7 +43,7 @@ tags: news
 
 <p>These seven new prototypes — a homepage, find your minimum wage, request a birth certificate, find official California state holidays, hire a licensed contractor for home improvements, and find food banks near you — are a work in progress. They’re iterations on where we started. They’ve been user tested (to the extent possible) and improved based on that feedback and will continue to be tested and iterated on. They’re not meant to be perfect, and we need your feedback to help make them better.</p>
 
-<p>The prototypes are as accessible as possible (each scores 100 on <a href="https://twitter.com/____lighthouse?lang=en">Lighthouse</a>). AAnd none exceed a 6th grade reading level. In these critical ways, they provide simpler, clearer, faster access to state government information and services.</p> 
+<p>The prototypes are as accessible as possible (each scores 100 on <a href="https://twitter.com/____lighthouse?lang=en">Lighthouse</a>). And none exceed a 6th grade reading level. In these critical ways, they provide simpler, clearer, faster access to state government information and services.</p> 
 
 <p>We hope you’ll give us feedback so that we can continue to learn, test, iterate and improve these pages.</p>
 
@@ -65,7 +65,7 @@ tags: news
 <h2>Find your minimum wage</h2>
 
 <ul>
-	<li><a href="http://www.https://GitHub.com/cagov/UX/issues/43">GitHub issue</a></li>
+	<li><a href="https://github.com/cagov/UX/issues/43">GitHub issue</a></li>
 	<li><a href="https://www.dir.ca.gov/dlse/faq_minimumwage.htm">Baseline</a></li>
 </ul>
 
@@ -100,7 +100,7 @@ tags: news
 	<li>Less isn’t always enough.</li>
 </ul>
 
-  <p>Check out the iterated “<a href="https://alpha.ca.gov/services/find-minimum-wage-your-city/">Find your minimum wage</a>” page</p>
+  <p>Check out the iterated “<a href="https://alpha.ca.gov/find-minimum-wage-your-city/">Find your minimum wage</a>” page</p>
 </ul>
 
 <h2>Request a birth certificate</h2>
@@ -136,7 +136,7 @@ tags: news
 	<li>“I like the button to be more at the bottom.”</li>
 </ul>
 
-<p>Check out the iterated “<a href="https://alpha.ca.gov/services/request-birth-certificate/">Request a birth certificate</a>” page</p>
+<p>Check out the iterated “<a href="https://alpha.ca.gov/request-birth-certificate/">Request a birth certificate</a>” page</p>
 	
 <h2>Find official California state holidays</h2>
 
@@ -170,7 +170,7 @@ tags: news
 	<li>“Link to add calendar looks out of place, breaks up the text in an odd way.”</li>
 </ul>
 
-<p>Check out the iterated “<a href="https://alpha.ca.gov/services/state-california-employee-holidays/">Find official California state holidays</a>” page</p>
+<p>Check out the iterated “<a href="https://alpha.ca.gov/state-california-employee-holidays/">Find official California state holidays</a>” page</p>
 	
 <h2>Hire a licensed contractor for home improvements</h2>
 
@@ -205,7 +205,7 @@ tags: news
 	<li>“Maybe should say more details.”</li>
 </ul>
 
-<p>Check out the iterated “<a href="https://alpha.ca.gov/services/hire-licensed-contractor-home-improvements/">Hire a licensed contractor for home improvements</a>” page</p>
+<p>Check out the iterated “<a href="https://alpha.ca.gov/hire-licensed-contractor-home-improvements/">Hire a licensed contractor for home improvements</a>” page</p>
 
 <h2>Find food banks near you</h2>
 
@@ -235,4 +235,4 @@ tags: news
 	<li>“Looks good. Could use some visuals, like what the places look like. Could use a picture to go with it. Would look up using zip code.”</li>
 </ul>
 
-<p>Check out the iterated “<a href="https://alpha.ca.gov/services/find-food-banks-near-you/">Find food banks near you</a>” page</p>
+<p>Check out the iterated “<a href="https://alpha.ca.gov/find-food-banks-near-you/">Find food banks near you</a>” page</p>

--- a/pages/blog/posts/alpha-ca-gov-product-release-3.html
+++ b/pages/blog/posts/alpha-ca-gov-product-release-3.html
@@ -185,6 +185,7 @@ tags: news
 				<a href="https://github.com/cagov/UX/issues/65">GitHub issue #65</a>
 			</li>
 			<li>
+				Baseline
 				<figure class="figure">
 					<img src="/img/thumb/Contact Agency_Baseline.jpg" alt="Screenshot of the current CA.gov “Contact a state agency” page.">
 					<figcaption class="figure-caption">Screenshot of the current CA.gov “Prepare for a wildfire" page."</figcaption>

--- a/pages/blog/posts/alpha-ca-gov-product-release-3.html
+++ b/pages/blog/posts/alpha-ca-gov-product-release-3.html
@@ -185,8 +185,6 @@ tags: news
 				<a href="https://github.com/cagov/UX/issues/65">GitHub issue #65</a>
 			</li>
 			<li>
-				<a href="https://cold.govops.ca.gov/">Baseline</a>
-
 				<figure class="figure">
 					<img src="/img/thumb/Contact Agency_Baseline.jpg" alt="Screenshot of the current CA.gov “Contact a state agency” page.">
 					<figcaption class="figure-caption">Screenshot of the current CA.gov “Prepare for a wildfire" page."</figcaption>

--- a/pages/blog/posts/alpha-ca-gov-spanish-translation.html
+++ b/pages/blog/posts/alpha-ca-gov-spanish-translation.html
@@ -10,16 +10,16 @@ tags: news
 ---
 
 <figure class="figure">
-  <img src="/{{ previewimage }}" class="" alt='Photo of a sticky note that says "En espanol."''>
+  <img src="/{{ previewimage }}" class="" alt='Photo of a sticky note that says "En espanol."'>
 </figure>
 
-<p>We hope you noticed that the first release of <a href="https://alpha.ca.gov.com">Alpha.CA.gov</a> prototypes included Spanish language versions.</p>
+<p>We hope you noticed that the first release of <a href="https://alpha.ca.gov">Alpha.CA.gov</a> prototypes included Spanish language versions.</p>
 
 <p>This is something we’re particularly proud of. Given our timeline and resources, these translations were initially out of scope for the first release. But they were always front of mind for <a href="https://twitter.com/abquirarte">Angie</a>, our product owner.</p>
 
 <p>Angie is a Mexican immigrant and Spanish is her first language. Growing up, Angie and her family spoke Spanish at home. Speaking a language other than English at home is something that over 40% of Californians also do. And, it's worth noting, <a href="https://blog.languageline.com/report-california-limited-english-proficient">“18.6% of California residents are considered limited English proficient (LEP), meaning they speak English less than ‘very well.’”</a></p>
 
-<p>We saw this in practice when we user tested the <a href="https://alpha.ca.gov/services/request-birth-certificate/">Find a birth certificate</a> prototype in the field: 3 out of 5 people were at the county office with translators because Spanish is their primary language.</p>
+<p>We saw this in practice when we user tested the <a href="https://alpha.ca.gov/request-birth-certificate/">Find a birth certificate</a> prototype in the field: 3 out of 5 people were at the county office with translators because Spanish is their primary language.</p>
 
 <p>This IRL reminder of California’s incredible cultural diversity inspired us to expand our scope and push to make Spanish translation part of release 1.</p>
 
@@ -39,7 +39,7 @@ tags: news
 <h3>Doing the translations forced us to revisit the English version to make it clearer, more accurate.</h3>
 <ul>
     <li>The English titles and section descriptions are spare, concise. In Spanish, those same titles and section headers are far more conversational.</li>
-    <li>As we translated the <a href="https://alpha.ca.gov/services/hire-licensed-contractor-home-improvements/">Hire a Licensed Contractor</a> page, we realized that the English version was not as clear as we thought it was. Doing the Spanish translation actually helped us iterate and improve the English version.</li>
+    <li>As we translated the <a href="https://alpha.ca.gov/hire-licensed-contractor-home-improvements/">Hire a Licensed Contractor</a> page, we realized that the English version was not as clear as we thought it was. Doing the Spanish translation actually helped us iterate and improve the English version.</li>
 </ul>
 
 <h3>Verbatim translations don’t work.</h3>
@@ -50,7 +50,7 @@ tags: news
 
 <h3>Finding materials in Spanish proved challenging - and so did translations of more technical content.</h3>
 <ul>
-    <li>There was no baseline Spanish translation available for the “More details about holidays” section on the <a href="https://alpha.ca.gov/services/state-california-employee-holidays/">State holidays</a> page. Without the help of a subject matter expert in that language, it was hard to know if we were using the correct terminology.</li>
+    <li>There was no baseline Spanish translation available for the “More details about holidays” section on the <a href="https://alpha.ca.gov/state-california-employee-holidays/">State holidays</a> page. Without the help of a subject matter expert in that language, it was hard to know if we were using the correct terminology.</li>
     <li>Even when available, the baseline content in Spanish was not always reliable because it had been translated using auto translate apps, which offer essentially verbatim translation. This meant additional vetting and reworking on our end to provide the appropriate context, tone, and wording we want to convey
     </li>
 </ul>

--- a/pages/blog/posts/and-were-in-progress.html
+++ b/pages/blog/posts/and-were-in-progress.html
@@ -26,10 +26,6 @@ tags: news
 
 <p>We’re sharing our work and insights on our blog, <a href="https://twitter.com/CAdotGov">Twitter</a> and <a href="https://github.com/cagov">GitHub</a>.</p>
 
-<h2>Share your feedback</h2>
-
-<p>Please take our <a href="https://www.surveymonkey.com/r/AlphaCAgov">five-minute survey</a> to help improve CA.gov. Thanks in advance for sharing your thoughts.</p>
-
 <p>We’re excited to work with you.</p>
 
 <p><em>Team Alpha.CA.gov</em></p>

--- a/pages/blog/posts/done-doing-dec-16-dec-22.html
+++ b/pages/blog/posts/done-doing-dec-16-dec-22.html
@@ -20,7 +20,7 @@ tags: news
 
 <ul>
 	<li>Developed MVP <a href="https://github.com/cagov/cwds/issues/17">design system</a> and page templates</li>
-	<li>Collected 50+ responses on the <a href="https://www.surveymonkey.com/r/AlphaCAgov">general Alpha survey</a></li>
+	<li>Collected 50+ responses on the <general Alpha survey</li>
 	<li>Guest team members (shout to CHHS Office of Innovation!) tested the <a href="https://github.com/cagov/UX/issues">State Holiday prototype</a> to learn how to handle 4th of July and validated that we want to keep Next Holiday feature</li>
 	<li>Conducted a <a href="https://twitter.com/CAdotGov/status/1207440359782928384">field research visit</a> to Vital Records office in South Sacramento to test “Request a birth certificate” with guest team members from CHHS Innovation team</li>
 	<li>Built new Function As A Service (<a href="https://github.com/cagov/FunctionApps">FAAS</a>, also called “serverless”) prototype and Github integrated deployment pipeline</li>

--- a/pages/blog/posts/done-doing-dec-9-dec-13.html
+++ b/pages/blog/posts/done-doing-dec-9-dec-13.html
@@ -21,11 +21,11 @@ tags: news
 <ul>
 	<li>Delivered the first iteration of the Alpha at <a href="https://alpha.ca.gov/">Alpha.CA.gov</a></li>
 	<li>Pushed site <a href="https://github.com/cagov/Alpha/issues/10">live on state’s Azure infrastructure</a></li>
-	<li>Created a <a href="https://www.surveymonkey.com/r/AlphaCAgov">user survey</a></li>
+	<li>Created a user survey</li>
 	<li>Identified initial set of user needs including: finding vital records, applying for Unemployment Insurance, Paid Family Leave, and Disability Insurance <em>(more to come on user needs in our blog and on social next week)</em></li>
 	<li>Delivered first user story on minimum wage, including <a href="https://github.com/cagov/Alpha/issues/26">functional prototypes</a> and <a href="https://github.com/cagov/UX/issues/4">content mockups</a></li>
 	<li>Established <a href="https://handbook-cadotgov.readthedocs.io/en/latest/principles/">design principles</a></li>
-	<li>Developed starter <a href="https://cagov.github.io/cwds/">web design system</a></li>
+	<li>Developed starter web design system</li>
 	<li>Picked a <a href="https://public-sans.digital.gov/">default font</a></li>
 </ul>
 

--- a/pages/blog/posts/done-doing-feb-10-feb-17.html
+++ b/pages/blog/posts/done-doing-feb-10-feb-17.html
@@ -39,6 +39,6 @@ tags: news
     <li>Retrieving homeless shelter data for a new API</li>
     <li>Prototyping a new content type for unemployment insurance</li>
 	<li>Building out the ‘Contact us’ directory</li>
-    <li><a href="https://cwds.dev/">CWDS</a> clean-up</li>
+    <li>CWDS clean-up</li>
     <li>Release 3 planning</li>
 </ul>

--- a/pages/blog/posts/re-imagining-ca-gov-how-can-california-government-better-serve-its-people.html
+++ b/pages/blog/posts/re-imagining-ca-gov-how-can-california-government-better-serve-its-people.html
@@ -78,14 +78,12 @@ tags: news
     <li>Product Designer</li>
 </ul>
 
-<p><strong><a href="https://govops.forms.fm/interest-form-ca-gov-alpha-team/">Learn more about these opportunities through this interest form.</a></strong></p>
-
 <h2>And in closing ...</h2>
 
 <p>This is the start. This is the first time we’re communicating about this effort, and we wanted to make sure that this post really drives home the incredible opportunity we have here.</p>
 
-<p>Governor Newsom’s <a href="https://en.wikipedia.org/wiki/Citizenville%29">“Citizenville”</a> envisioned a government that better serves its people by better understanding their needs. And right now, there is no question that California is a state dealing with many needs and many challenges. We believe that a big part of meeting these needs and addressing these challenges starts by re-imagining CA.gov.</p>
+<p>Governor Newsom’s <a href="https://en.wikipedia.org/wiki/Citizenville">Citizenville</a> envisioned a government that better serves its people by better understanding their needs. And right now, there is no question that California is a state dealing with many needs and many challenges. We believe that a big part of meeting these needs and addressing these challenges starts by re-imagining CA.gov.</p>
 
-<p><a href="https://govops.forms.fm/interest-form-ca-gov-alpha-team/forms/7391">Join this mission.</a> Together we can fulfill the vision of a California for All.</p>
+<p>Join this mission. Together we can fulfill the vision of a California for All.</p>
 
 <p>Follow our journey on <a href="https://twitter.com/CAdotGov">Twitter</a> and Medium.</p>


### PR DESCRIPTION
Fixing broken links and misspellings identified by SiteImprove in Alpha blog posts.