### PR TITLE
Turned on HideAuthorName.

### DIFF
--- a/wordpress/wordpress-to-github.config.json
+++ b/wordpress/wordpress-to-github.config.json
@@ -10,6 +10,7 @@
     "PagePath": "pages/wordpress-pages",
     "MediaPath": "wordpress/media",
     "GeneralFilePath": "wordpress/general/general.json",
-    "ExcludeProperties": ["content", "_links"]
+    "ExcludeProperties": ["content", "_links"],
+    "HideAuthorName": true
   }
 }


### PR DESCRIPTION
Turning on HideAuthorName in wordpress-to-github config file, to prevent /users/ API endpoint from being read, so we can turn off this endpoint.