### PR TITLE
Three styling fixes

### DIFF
--- a/src/css/_projects.scss
+++ b/src/css/_projects.scss
@@ -92,3 +92,8 @@
 h2.wp-block-heading {
   margin-top: 4rem;
 }
+
+div.ds-content-layout {
+  padding-left: 10px;
+  padding-right: 10px;
+}

--- a/src/css/_projects.scss
+++ b/src/css/_projects.scss
@@ -28,6 +28,12 @@
     border: none;
   }
 }
+.entry-content {
+  figure img {
+    margin-bottom: 0; 
+  }
+}
+
 .cagov-project-bubble-points {
   margin: 3rem auto;
 }

--- a/src/css/_projects.scss
+++ b/src/css/_projects.scss
@@ -88,3 +88,7 @@
   font-size: 1.2rem;
   margin-bottom: 0;
 }
+
+h2.wp-block-heading {
+  margin-top: 4rem;
+}


### PR DESCRIPTION
Based on Kimberly's feedback here:

https://www.figma.com/file/Dev3ulmslbUYJPkaCLDnJm/Innovation.ca.gov-screens?type=design&node-id=2581-13748&mode=design&t=1w7tx3Ox3ms0k9Kt-0

1. Removed margin from bottom of hero figure.
2. Increased spacing on top of h2s by about 2x.
3. Added 10px padding to content section to match the padding on headers and footers.

The last two fixes affect many other pages on the site (not just project pages), which have the same issues.  Please check a few other pages to confirm that these changes are desired there as well.