### PR TITLE
Apply flex-wrap to bubble-points

### DIFF
--- a/src/css/_projects.scss
+++ b/src/css/_projects.scss
@@ -41,6 +41,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-flow: row wrap;
 
   .cagov-project-bubble-point {
     background: #ecf1f6;


### PR DESCRIPTION
Fixes #205.

The mobile responsiveness problem was caused by our implementation of the bubble points, shown below.

<img width="845" alt="Screenshot 2023-07-26 at 13 05 30" src="https://github.com/cagov/innovation.ca.gov/assets/1208960/6a343ff4-8302-4091-85c2-2fa2a62b537b">


In some (but not all) mobile browsers, these two bubbles would lock into a row, preventing the rest of the page from shrinking. This fix helps those bubbles break into a column at smaller screen sizes.

