### PR TITLE
Change flex properties of project summaries

### DIFF
--- a/src/css/_projects.scss
+++ b/src/css/_projects.scss
@@ -7,7 +7,7 @@
 .project-page-summary-list > .wp-block-group__inner-container {
   display: flex;
   flex-flow: row wrap;
-  column-gap: 2rem
+  column-gap: 2rem;
 }
 .project-page-summary-list > .wp-block-group__inner-container > .wp-block-group {
   flex-basis: 22rem;

--- a/src/css/_projects.scss
+++ b/src/css/_projects.scss
@@ -2,13 +2,16 @@
   padding: 1.5rem;
   background-color: #ECF1F6;
   font-size: .875rem;
+  margin-bottom: 4rem;
 }
 .project-page-summary-list > .wp-block-group__inner-container {
   display: flex;
+  flex-flow: row wrap;
+  column-gap: 2rem
 }
 .project-page-summary-list > .wp-block-group__inner-container > .wp-block-group {
-  margin-right: 2rem;
-  max-width: 50%;
+  flex-basis: 22rem;
+  flex-grow: 1;
 
   li {
     margin-bottom: 0;


### PR DESCRIPTION
Addresses the concerns listed here:

https://www.figma.com/file/Dev3ulmslbUYJPkaCLDnJm/Innovation.ca.gov-screens?type=design&node-id=2631-1032&mode=design&t=k9BFaNoEAOzwPPOo-0

The flex properties of the "Project Scope" section have been altered to help out on mobile.

Before:
<img width="422" alt="Screenshot 2023-07-27 at 11 23 03" src="https://github.com/cagov/innovation.ca.gov/assets/1208960/fa58c8a7-9064-4b09-a53f-526576cac3b0">

After:
<img width="417" alt="Screenshot 2023-07-27 at 11 23 33" src="https://github.com/cagov/innovation.ca.gov/assets/1208960/116af9c3-5936-4c90-8741-839807d15c76">
