### PR TITLE
Removed call to changedomain in social media headers.

### DIFF
--- a/pages/_includes/base-layout.njk
+++ b/pages/_includes/base-layout.njk
@@ -21,7 +21,7 @@
     <meta property="og:description" content="{{ data.og_meta.open_graph_description | striptags }}" />
     <meta property="og:title" content="{{ title | safe }}" />
     <meta property="og:type" content="website" />
-    <meta property="og:image" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_url | changeDomain(domain) }}{% else %}{% if previewimage %}/{{ previewimage }}{% else %}https://innovation.ca.gov/img/ODI-socialmedia-share_1200x630.png{% endif %}{% endif %}" />
+    <meta property="og:image" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_url }}{% else %}{% if previewimage %}/{{ previewimage }}{% else %}https://innovation.ca.gov/img/ODI-socialmedia-share_1200x630.png{% endif %}{% endif %}" />
     <meta property="og:image:width" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_width }}{% else %}{% if previewimage %}608{% else %}1200{% endif %}{% endif %}" />
     <meta property="og:image:height" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_height }}{% else %}{% if previewimage %}304{% else %}630{% endif %}{% endif %}" />
     <meta property="og:image:alt" content="{% if data.og_meta.page_social_image_alt %}{{ data.og_meta.page_social_image_alt }}{% endif %}" />
@@ -29,7 +29,7 @@
     <meta property="og:site_name" content="{{ data.og_meta.site_name }}" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{{ data.og_meta.twitter_title | safe }}" />
-    <meta property="twitter:image" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_url | changeDomain(domain) }}{% else %}{% if previewimage %}/{{ previewimage }}{% else %}https://innovation.ca.gov/img/ODI-socialmedia-share_1200x630.png{% endif %}{% endif %}" />
+    <meta property="twitter:image" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_url }}{% else %}{% if previewimage %}/{{ previewimage }}{% else %}https://innovation.ca.gov/img/ODI-socialmedia-share_1200x630.png{% endif %}{% endif %}" />
     <meta property="twitter:image:alt" content="{% if data.og_meta.page_social_image_alt %}{{ data.og_meta.page_social_image_alt }}{% endif %}" />
     <meta property="twitter:image:width" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_width }}{% else %}{% if previewimage %}608{% else %}1200{% endif %}{% endif %}" />
     <meta property="twitter:image:height" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_height }}{% else %}{% if previewimage %}304{% else %}630{% endif %}{% endif %}" />


### PR DESCRIPTION
@mediajunkie noticed that shared links to our recent blog post were not correctly showing preview on linked in.  The linked page was [here](https://innovation.ca.gov/our-work/projects/getting-compensation-to-more-california-crime-victims/).

Inspecting the social media headers, I noticed the image links were 404ing.  

This turned out to be due to an eleventy filter, _changedomain_, which was changing the domain of the media library to innovation.ca.gov, which does not currently host the media library at the same path.  I removed the use of this filter (which was only used in the social media headers), and now the image links in the social media headers have valid URLs.

The invalid (translated) image link was: 

https://innovation.ca.gov/wp-content/uploads/2023/05/cropped-vcb-project-header-photo.jpg

it should be

https://live-digital-ca-gov.pantheonsite.io/wp-content/uploads/2023/05/cropped-vcb-project-header-photo.jpg

Which is what Michael originally used.