### PR TITLE
Issue #210. Styling tweaks to align left margin.

### DIFF
--- a/src/css/_layouts-extra.scss
+++ b/src/css/_layouts-extra.scss
@@ -23,7 +23,7 @@ main .cagov-single-column h2:first-child {
 }
 
 main.landing-page {
-  padding-left: 1rem;
+  /* padding-left: 1rem; */ /* jbum align */
   .cagov-featured-sidebar {
     padding-left: 0;
   }

--- a/src/css/_layouts-extra.scss
+++ b/src/css/_layouts-extra.scss
@@ -4,6 +4,9 @@ this class is applied to content on that page we want to be centered. Most conte
   max-width: var(--w-page-content,876px);
   margin: 0 auto;
 }
+// .has-sidebar-left .single-column {
+//   margin-left: 8px; /* jbum align */
+// }
 @media only screen and (max-width: 1176px) {
   .cagov-single-column, .single-column {
     padding-left: 1rem;

--- a/src/css/_projects.scss
+++ b/src/css/_projects.scss
@@ -97,7 +97,7 @@ h2.wp-block-heading {
   margin-top: 4rem;
 }
 
-div.ds-content-layout {
-  padding-left: 10px;
-  padding-right: 10px;
-}
+// div.ds-content-layout {
+//   padding-left: 10px;
+//   padding-right: 10px;
+// }

--- a/src/css/_theme-overrides.scss
+++ b/src/css/_theme-overrides.scss
@@ -7,6 +7,12 @@ body {
   background: var(--primary-dark-color, #00315f);
   color: #fff;
 }
+.official-header .container {
+  padding-left: 24px; /* jbum align */
+}
+.page-container-ds {
+  padding-left:16px; /* jbum align */
+}
 cagov-site-navigation, .site-header {
   background: transparent;
   border-bottom: solid 1px var(--primary-color, #0D4F8C);

--- a/src/css/_theme-overrides.scss
+++ b/src/css/_theme-overrides.scss
@@ -12,6 +12,7 @@ body {
 }
 .page-container-ds {
   padding-left:16px; /* jbum align */
+  padding-right:16px; /* jbum align */
 }
 cagov-site-navigation, .site-header {
   background: transparent;


### PR DESCRIPTION
Adds adjustments so that left margins are aligned on most pages, addressing issue #210.
Removes an adjustment from the home-page that is now covered by site-wide styling.

BEFORE
<img width="538" alt="CleanShot 2023-08-01 at 16 18 01" src="https://github.com/cagov/innovation.ca.gov/assets/287977/94e07f30-d762-4231-9a12-42b6fb405ff3">

AFTER
<img width="527" alt="CleanShot 2023-08-01 at 16 18 27" src="https://github.com/cagov/innovation.ca.gov/assets/287977/0084ab87-9b73-4634-8556-887e633647cf">
