### PR TITLE
Styling fix in preparation for DTSC project page.

### DIFF
--- a/pages/_includes/base-layout.njk
+++ b/pages/_includes/base-layout.njk
@@ -22,8 +22,6 @@
     <meta property="og:title" content="{{ title | safe }}" />
     <meta property="og:type" content="website" />
     <meta property="og:image" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_url }}{% else %}{% if previewimage %}/{{ previewimage }}{% else %}https://innovation.ca.gov/img/ODI-socialmedia-share_1200x630.png{% endif %}{% endif %}" />
-    <meta property="og:image:width" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_width }}{% else %}{% if previewimage %}608{% else %}1200{% endif %}{% endif %}" />
-    <meta property="og:image:height" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_height }}{% else %}{% if previewimage %}304{% else %}630{% endif %}{% endif %}" />
     <meta property="og:image:alt" content="{% if data.og_meta.page_social_image_alt %}{{ data.og_meta.page_social_image_alt }}{% endif %}" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:site_name" content="{{ data.og_meta.site_name }}" />

--- a/pages/_includes/base-layout.njk
+++ b/pages/_includes/base-layout.njk
@@ -29,10 +29,6 @@
     <meta property="og:site_name" content="{{ data.og_meta.site_name }}" />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:title" content="{{ data.og_meta.twitter_title | safe }}" />
-    <meta property="twitter:image" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_url }}{% else %}{% if previewimage %}/{{ previewimage }}{% else %}https://innovation.ca.gov/img/ODI-socialmedia-share_1200x630.png{% endif %}{% endif %}" />
-    <meta property="twitter:image:alt" content="{% if data.og_meta.page_social_image_alt %}{{ data.og_meta.page_social_image_alt }}{% endif %}" />
-    <meta property="twitter:image:width" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_width }}{% else %}{% if previewimage %}608{% else %}1200{% endif %}{% endif %}" />
-    <meta property="twitter:image:height" content="{% if data.og_meta.page_social_image_url %}{{ data.og_meta.page_social_image_height }}{% else %}{% if previewimage %}304{% else %}630{% endif %}{% endif %}" />
     <!-- CSS -->
     {% block css %}
       {% set css %}

--- a/src/css/_projects.scss
+++ b/src/css/_projects.scss
@@ -53,7 +53,7 @@
     height: 238px;
     border-radius: 50%;
     padding: 1.5rem;
-    margin: 1rem;
+    margin: 0.5rem;
     text-align: center;
     display: flex;
     align-items: center;


### PR DESCRIPTION
In issue #212 (https://github.com/cagov/innovation.ca.gov/issues/212), Kimberly identified three issues.

1. Social media preview does not appear to be working for LinkedIn. I have not yet fixed this.
2. Social media preview does not work for Twitter (addressed here).
3. Bubbles need a narrow margin so we can fit 3 bubbles on a line (fixed here).

There were two issues with the Twitter social media tags.  One is that twitter uses the keyword 'name' instead of 'property' in its social media meta tags, as described here.  https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started#started

Secondly, Twitter is perfectly happy to use the old school og: tags if they are provided, and we do provide them, so there is no need to provide redundant tags for twitter.  I have addressed both issues by removing the redundant twitter-specific tags we were providing.

I have not yet identified what is going on with LinkedIn. I noticed that the image height we are providing (in the meta tag, at least), exceeds LinkedIn's maximum image height of 627 (3 pixels shorter than the usual Facebook image).  

Moreover, I noticed that the image height/width we are providing appears to be forced to 1200/630 and does not actually match the dimensions of the underlying image.  For now I am going to remove the width/height identifiers, because I believe they are optional.  Will use the PR preview site to test on several social media sites.

