### PR TITLE
Update site-navigation.njk

### DIFF
--- a/pages/_includes/site-navigation.njk
+++ b/pages/_includes/site-navigation.njk
@@ -71,7 +71,7 @@
               </button>
             </strong>
             <div class="expanded-menu-dropdown" id="our-work">
-                <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/our-work/projects/?activeTab=past-projects-btn" tabindex="-1">Projects</a>
+                <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/our-work/projects/" tabindex="-1">Projects</a>
                 <a class="expanded-menu-dropdown-link js-event-hm-menu" href="/our-work/innovation-community-of-practice/" tabindex="-1">Innovation Community of Practice</a>
             </div>
           </div>


### PR DESCRIPTION
Now that we're no longer pursuing the tabbed version of the _Projects_ page from a year ago, I think we can clean up the URL in the site navigation for the page. Review to make sure this is OK to do is appreciated. 🙂 