### PR TITLE
Preventative measure to provide unrounded numbers from displaying. Fi…

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -211,6 +211,10 @@ module.exports = function (eleventyConfig) {
     return readabilityScore;
   })
 
+  eleventyConfig.addFilter('roundNumber', (value) => {
+    return Math.round(parseFloat(value));
+  })
+
   eleventyConfig.addFilter('getScoreColor', (value) => {
     if(parseInt(value) > 89) {
       return 'speedlify-score-good';

--- a/pages/_includes/par-scores.njk
+++ b/pages/_includes/par-scores.njk
@@ -5,7 +5,7 @@
     {% if performance[page.url].lighthouse.performance %}
       <span class="page-score-details">
         <span class="page-score-block p-a-2">
-          <span class="speedlify-score {{(performance[page.url].lighthouse.performance * 100) | getScoreColor }}">{{performance[page.url].lighthouse.performance * 100}}</span>
+          <span class="speedlify-score {{(performance[page.url].lighthouse.performance * 100) | getScoreColor }}">{{(performance[page.url].lighthouse.performance * 100) | roundNumber }}</span>
           <span>Performance</span>
         </span>
         <a href="/page-score-info/#performance">Why is performance important</a>
@@ -14,7 +14,7 @@
     {% if performance[page.url].lighthouse.accessibility %}
       <span class="page-score-details">
         <span class="page-score-block p-a-2">
-          <span class="speedlify-score {{ (performance[page.url].lighthouse.accessibility  * 100) | getScoreColor }}">{{performance[page.url].lighthouse.accessibility  * 100}}</span>
+          <span class="speedlify-score {{ (performance[page.url].lighthouse.accessibility  * 100) | getScoreColor }}">{{(performance[page.url].lighthouse.accessibility  * 100) | roundNumber }}</span>
           <span>Accessibility</span>
         </span>
         <a href="/page-score-info/#accessibility">Why is accessibility important</a>


### PR DESCRIPTION
Fixes a bug observed on hub.innovation.ca.gov which uses the same code.

![CleanShot 2023-12-22 at 14 28 07](https://github.com/cagov/innovation.ca.gov/assets/287977/5d6d8e67-ceed-4993-a765-d3b4a372937c)

The numbers in the json was definitely .58, and multiplying it by 100 was causing the sporadic rounding error seen in many modern chipsets.  Added a roundNumber filter to prevent this.