### PR TITLE
Fix problems with site build

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -122,9 +122,15 @@ module.exports = function (eleventyConfig) {
         item.data.tags = jsonData.tags;
 
         // WordPress will lazy load everything and you have to put php code in your theme to override it. We don't want to lazy load our featuref image
-        item.template.frontMatter.content = item.template.frontMatter.content.replace('loading="lazy" class="cagov-featured-image','class="cagov-featured-image');
+        //item.template.frontMatter.content = item.template.frontMatter.content.replace('loading="lazy" class="cagov-featured-image','class="cagov-featured-image');
 
-        let html = item.template.frontMatter.content;
+        let html = await item.template.read().then(t => {
+          return t.content
+        });
+
+        // WordPress will lazy load everything and you have to put php code in your theme to override it. We don't want to lazy load our featuref image
+        html = html.replace('loading="lazy" class="cagov-featured-image','class="cagov-featured-image');
+        
         // Temporary rewrite of feature card h2 tag to h1. This is fixed in newer version of Gutenberg blocks plugin still under review so can be deleted when this no longer comes through as h2 causing a11y test failures
         if (html.indexOf('cagov-featured-sidebar') > -1) {
           const {

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -61,7 +61,7 @@ module.exports = function (eleventyConfig) {
     const FolderNamePages = "wordpress-pages";
     let output = [];
 
-    collection.getAll().forEach((item) => {
+    collection.getAll().forEach(async (item) => {
       item.data.domain = 'innovation.ca.gov';
       if (item.inputPath.includes(FolderNamePosts)) {
         item.outputPath = item.outputPath.replace(`/${FolderNamePosts}`, "");


### PR DESCRIPTION
Need to fix recent problems with site build.

```
[11ty] Unfortunately you’re using code that monkey patched some Eleventy internals and it isn’t async-friendly. Change your code to use the async `read()` method on the template instead! (via Error)
[11ty] 
[11ty] Original error stack trace: Error: Unfortunately you’re using code that monkey patched some Eleventy internals and it isn’t async-friendly. Change your code to use the async `read()` method on the template instead!
```