### PR TITLE
Google Analytics Test

### DIFF
--- a/pages/_includes/analytics.njk
+++ b/pages/_includes/analytics.njk
@@ -1,22 +1,4 @@
 <script>
-/**
-
-// "CLASSIC" google analytics
-
-window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
-ga('create', 'UA-20973992-35', 'auto'); // my specific site
-ga('create', 'UA-3419582-2', 'auto', 'tracker2'); // all ca.gov
-ga('send', 'pageview');
-ga('tracker2.send', 'pageview');
-
-window.onload = function() {
-  let s = document.createElement("script");
-  s.type = "text/javascript";
-  s.src = "https://www.google-analytics.com/analytics.js";
-  document.head.append(s);
-}
-**/
-
 // GA4 (new) Google Analytics
 
 // Based on template provided here:

--- a/pages/_includes/analytics.njk
+++ b/pages/_includes/analytics.njk
@@ -1,8 +1,10 @@
 <script>
+
 // GA4 (new) Google Analytics
 
 // Based on template provided here:
 // https://webstandards.ca.gov/add-analytics-to-your-site/
+
 (function () {
   const ga = document.createElement("script");
   ga.async = true;
@@ -16,6 +18,7 @@ window.gtag = function () {
   dataLayer.push(arguments);
 };
 gtag("js", new Date());
-gtag("config", "G-69TD0KNT0F"); // Statewide GA4 measurement ID
+// gtag("config", "G-69TD0KNT0F"); // Statewide GA4 measurement ID
 gtag("config", "G-70MEKX9MZC"); // innovation.ca.gov ID
+
 </script>


### PR DESCRIPTION
All our websites use two different GA4 ids for google analytics.  Like so:

```
gtag("config", "G-69TD0KNT0F"); // Statewide GA4 measurement ID
gtag("config", "G-70MEKX9MZC"); // innovation.ca.gov ID
```
The code we use to set up those two ids (copied from several canonical google examples) causes two separate loads of Google's tagmanager script. 

Before going crazy trying to fix this, I'd like to understand the actual effect, if any, this double load has on the page performance score.  So I am turning off one of the IDs (the statewide one) for a couple hours, so I can remeasure the site across all the pages, and measure the cumulative performance gain.  

```
// gtag("config", "G-69TD0KNT0F"); // Statewide GA4 measurement ID
gtag("config", "G-70MEKX9MZC"); // innovation.ca.gov ID
```


If it turns out to be quite small, we can probably ignore this issue.