### PR TITLE
Inhibits display of PAR footer

### DIFF
--- a/pages/_includes/par-scores.njk
+++ b/pages/_includes/par-scores.njk
@@ -1,4 +1,4 @@
-  <div class="page-score-info">
+  <div class="page-score-info" style="display:none">
   <p>ODI grades the reading level, performance, and accessibility of all our webpages. Here are this page’s scores as of the last update:</p>
 
   <div class="score-display">
@@ -31,3 +31,11 @@
     {% endif %}
   </div>
 </div>
+
+<script>
+// using URLSearchParam, if parameter 'par' is present then show the above page-score-info div
+var urlParams = new URLSearchParams(window.location.search);
+if (urlParams.has('par')) {
+  document.querySelector('.page-score-info').style.display = 'block';
+}
+</script>

--- a/pages/_includes/par-scores.njk
+++ b/pages/_includes/par-scores.njk
@@ -33,7 +33,7 @@
 </div>
 
 <script>
-// using URLSearchParam, if parameter 'par' is present then show the above page-score-info div
+// using URLSearchParam, if parameter 'par' is present then show the above page-score-info div 
 var urlParams = new URLSearchParams(window.location.search);
 if (urlParams.has('par')) {
   document.querySelector('.page-score-info').style.display = 'block';


### PR DESCRIPTION
Inhibits public display of PAR (Performance, Accessibility, Readability) footer.

The footer is still produced during the build, but marked 'display:none'.  Its display is toggled on if ?par is appended to the URL.


