### PR TITLE
Changed to use of Google Tag Manager instead of GA4.

### DIFF
--- a/pages/_includes/analytics-body.njk
+++ b/pages/_includes/analytics-body.njk
@@ -1,0 +1,4 @@
+<!-- Google Tag Manager (noscript) <body> code -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-PQRTS7Z8"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->

--- a/pages/_includes/analytics-head.njk
+++ b/pages/_includes/analytics-head.njk
@@ -1,0 +1,7 @@
+<!-- Google Tag Manager <head> code -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-PQRTS7Z8');</script>
+<!-- End Google Tag Manager -->

--- a/pages/_includes/analytics.njk
+++ b/pages/_includes/analytics.njk
@@ -1,6 +1,6 @@
 <script>
 
-// GA4 (new) Google Analytics
+// GA4 Google Analytics - NO LONGER USED
 
 // Based on template provided here:
 // https://webstandards.ca.gov/add-analytics-to-your-site/

--- a/pages/_includes/base-layout.njk
+++ b/pages/_includes/base-layout.njk
@@ -1,6 +1,10 @@
 <!doctype html>
 <html lang="en" xml:lang="en">
   <head>
+    {% block analytics_head %}
+      {% include "analytics-head.njk" %}
+    {% endblock %}
+
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
     <meta content="en" http-equiv="Content-Language">
     <meta content="IE=edge" http-equiv="X-UA-Compatible">
@@ -58,6 +62,9 @@
     {% endblock %}
   </head>
   <body>
+    {% block analytics_body %}
+      {% include "analytics-body.njk" %}
+    {% endblock %}
     <div id="skip-to-content"><a href="#body-content">Skip to content</a></div>
 
     <header class="header-container">
@@ -86,9 +93,9 @@
         {% include "statewide-footer.njk" %}
       {% endblock %}
     </div>
-    {% block analytics %}
+    {# {% block analytics %}
       {% include "analytics.njk" %}
-    {% endblock %}
+    {% endblock %} #}
   </body>
 </html>
 


### PR DESCRIPTION
Based on my discussions with Regan.  We are going to start using GTM on the innovation site to give him some more tracking flexibility.  Will continue to use GA4, for now, on hub and alpha sites.