### PR TITLE
Use 11ty collections to display all PAR data

### DIFF
--- a/pages/_includes/par-statistics.njk
+++ b/pages/_includes/par-statistics.njk
@@ -72,12 +72,12 @@
                 <div class="sort-tab" data-sort-col="3"  >Readability (ari)</div>
             </div>
             <div class="par-stats-table">
-            {% for key, prec in performance %}
+            {% for item in collections.all %}
                 <div class="par-stats-entry">
-                <div class="table-cell page-name" data-col-idx="0" data-sort-val="{{key}}"><a href="{{key}}?par=1">{{key}}</a></div>
-                <div class="table-cell" data-col-idx="1" data-sort-val="{{prec.lighthouse.performance}}"><span class="speedlify-score {{(prec.lighthouse.performance * 100) | getScoreColor }}">{{ (prec.lighthouse.performance * 100) | roundNumber }}</span></div>
-                <div class="table-cell" data-col-idx="2" data-sort-val="{{prec.lighthouse.accessibility}}"><span class="speedlify-score {{ (prec.lighthouse.accessibility  * 100) | getScoreColor }}">{{ (prec.lighthouse.accessibility * 100) | roundNumber }}</span></div>
-                <div class="table-cell" data-col-idx="3" data-sort-val="{{readability[key].readability.ari | calculateReadabilityGrade}}"><span data-ari-score="{{readability[key].readability.ari}}" class="speedlify-score {{ readability[key].readability.ari | calculateReadabilityGrade | getScoreColor }}">{{ readability[key].readability.ari | calculateReadabilityGrade }}</span></div>
+                <div class="table-cell page-name" data-col-idx="0" data-sort-val="{{item.url}}"><a href="{{item.url}}?par=1">{{item.url}}</a></div>
+                <div class="table-cell" data-col-idx="1" data-sort-val="{{item.data.lighthouse.performance.displayScore}}"><span class="speedlify-score {{item.data.lighthouse.performance.displayClass}}">{{item.data.lighthouse.performance.displayScore}}</span></div>
+                <div class="table-cell" data-col-idx="2" data-sort-val="{{item.data.lighthouse.accessibility.displayScore}}"><span class="speedlify-score {{item.data.lighthouse.accessibility.displayClass}}">{{item.data.lighthouse.accessibility.displayScore}}</span></div>
+                <div class="table-cell" data-col-idx="3" data-sort-val="{{item.data.readability.displayScore}}"><span data-ari-score="{{item.data.readability.ari}}" class="speedlify-score {{item.data.readability.displayClass}}">{{item.data.readability.displayScore}}</span></div>
                 </div>
 
             {% endfor %}


### PR DESCRIPTION
This change demonstrates how to collect all PAR scores on a page when using the newer 11ty-data-cascade-style setup for per-page scoring.

The key insight here is to take advantage of [11ty's Collections feature](https://www.11ty.dev/docs/collections/). Within a given template, this allows us to iterate over the data for many pages across the site. While it's typically useful for generating things like sitemaps or blog listings, we can also use it to list the PAR data.

This PR currently uses the generic `collections.all` built-in collection to get all pages. For more control over the list, check out the 11ty docs for more details on [how to do fine-grained filtering and sorting in a custom collection](https://www.11ty.dev/docs/collections/#advanced-custom-filtering-and-sorting).