### PR TITLE
Replaced use of unmaintained n1hility plugin with newer concurrency feature.

### DIFF
--- a/.github/workflows/deploy_dev_aws.yml
+++ b/.github/workflows/deploy_dev_aws.yml
@@ -5,13 +5,17 @@ on:
     branches:
       - development
 
+concurrency: # replaces use of n1hility/cancel-previous-runs
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: n1hility/cancel-previous-runs@master
-        with: 
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # - uses: n1hility/cancel-previous-runs@master
+      #   with: 
+      #     token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@master
       - name: Use Node.js 
         uses: actions/setup-node@master

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -5,13 +5,17 @@ on:
     branches:
       - main
 
+concurrency: # replaces use of n1hility/cancel-previous-runs
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: n1hility/cancel-previous-runs@master
-        with: 
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # - uses: n1hility/cancel-previous-runs@master
+      #   with: 
+      #     token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@master
       - name: Use Node.js 
         uses: actions/setup-node@master

--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -6,13 +6,18 @@ on:
       - synchronize
       - ready_for_review
       - reopened
+
+concurrency: # replaces use of n1hility/cancel-previous-runs
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build_deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: n1hility/cancel-previous-runs@master
-        with: 
-          token: ${{ secrets.GITHUB_TOKEN }}
+      # - uses: n1hility/cancel-previous-runs@master
+      #   with: 
+      #     token: ${{ secrets.GITHUB_TOKEN }}
       - uses: actions/checkout@master
       - name: Use Node.js 18
         uses: actions/setup-node@master


### PR DESCRIPTION
The n1hility plugin we use to cancel previous runs is no longer maintained, and is using a deprecated version of node.
Since this plugin was written, github has introduced a built-in feature to handle concurrency.  

This patch uses it.

More info here: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency