### PR TITLE
Removed overflow:hidden from bubble styling.

### DIFF
--- a/src/css/_projects.scss
+++ b/src/css/_projects.scss
@@ -57,7 +57,6 @@
     text-align: center;
     display: flex;
     align-items: center;
-    overflow: hidden;
     font-size: 1.125rem;
 
     div, p {


### PR DESCRIPTION
Removed overflow:hidden from bubble styling since it is unnecessary and may trigger false positives in SiteImprove