### PR TITLE
Testing speed improvement (issue #259)

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "site:watch:dev": "cross-env NODE_ENV=development eleventy --serve --incremental",
     "site:watch": "eleventy --serve",
     "start": "npm run site:watch",
-    "test": "npx playwright test test/index.spec.mjs",
+    "test": "npx playwright test test/index.spec.mjs test/index.blog.mjs",
     "test:serve": "npm run build && npx http-server _site/",
     "test:setup": "npx playwright install-deps chromium && npx playwright install"
   },

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "site:watch:dev": "cross-env NODE_ENV=development eleventy --serve --incremental",
     "site:watch": "eleventy --serve",
     "start": "npm run site:watch",
-    "test": "npx playwright test test/index.spec.mjs test/index.blog.mjs",
+    "test": "npx playwright test",
     "test:serve": "npm run build && npx http-server _site/",
     "test:setup": "npx playwright install-deps chromium && npx playwright install"
   },

--- a/playwright.config.mjs
+++ b/playwright.config.mjs
@@ -2,6 +2,7 @@
 // @ts-check
 /** @type {import('@playwright/test').PlaywrightTestConfig} */
 const config = {
+  testDir: './test',
   webServer: {
     command: 'npm run test:serve',
     port: 8080,

--- a/test/index-blog.spec.mjs
+++ b/test/index-blog.spec.mjs
@@ -1,0 +1,49 @@
+import fs from "fs";
+import { test, expect } from "@playwright/test";
+import { injectAxe, checkA11y } from "axe-playwright";
+
+let testLocation = "http://localhost:8080";
+
+let pageList = JSON.parse(fs.readFileSync("./_site_dist/allFiles.json"));
+let pageUrls = pageList.map((page) => page.url);
+
+// filter pageUrls to only include pages that are in the blog
+pageUrls = pageUrls.filter((pageUrl) => pageUrl.includes('/blog/'));
+
+pageUrls.forEach((pageUrl) => {
+  test(`desktop: a11y page tests: ${pageUrl}`, async ({ page }) => {
+    // use default viewport size which is desktop
+    await page.goto(testLocation + pageUrl);
+
+    await injectAxe(page);
+
+    await checkA11y(page, null, {
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+    });
+  });
+});
+
+/*
+
+// run same tests on mobile too
+pageUrls.forEach(pageUrl => {
+
+  test("mobile: a11y page tests "+pageUrl, async ({ page }) => {
+    await page.setViewportSize({
+      width: 360,
+      height: 740,
+    });
+
+    await page.goto(testLocation+pageUrl);
+  
+    await injectAxe(page);
+
+    await checkA11y(page, null, {
+      detailedReport: true,
+      detailedReportOptions: { html: true },
+    })
+  
+  });
+});
+*/

--- a/test/index.spec.mjs
+++ b/test/index.spec.mjs
@@ -7,7 +7,11 @@ let testLocation = "http://localhost:8080";
 let pageList = JSON.parse(fs.readFileSync("./_site_dist/allFiles.json"));
 let pageUrls = pageList.map((page) => page.url);
 
+// filter pageUrls to only include pages that are not in the blog
+pageUrls = pageUrls.filter((pageUrl) => !pageUrl.includes('/blog/'));
+
 pageUrls.forEach((pageUrl) => {
+  
   test(`desktop: a11y page tests: ${pageUrl}`, async ({ page }) => {
     // use default viewport size which is desktop
     await page.goto(testLocation + pageUrl);


### PR DESCRIPTION
There is an ongoing issue (#259) with this repo in that the tests run slowly.  When github is especially overloaded, this has occasionally caused publishing to fail.  [Here is an example run](https://github.com/cagov/innovation.ca.gov/actions/runs/7848250733/job/21418945066) where this happened last February.

This patch divides the tests into two roughly equal sized tasks that are executed in parallel.  One handles all the blog posts, and the other handles the remainder of the pages.  This should provide a significant speed up, and will (hopefully) speed up publishing.  

In the future, as the blog posts increase, we should divide the tests further, but this should be adequate for a good while.

In addition to the speed improvement, I've added the default testing directory to the playwright config, so that the testing files don't need to be explicitly called out in the package file.  All files in the test/ directory that end in spec.mjs will be run in parallel.