### PR TITLE
Added accessibility testing in PR builds.

### DIFF
--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Build 11ty
         run: |
           mkdir dist
+          npm install --legacy-peer-deps
           npm ci --production
           DOMAIN=${URLSAFE_BRANCH_NAME}.pr.digital.ca.gov npm run build
           npx playwright install

--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -43,7 +43,6 @@ jobs:
         run: |
           mkdir dist
           npm install --legacy-peer-deps
-          npm ci --production
           DOMAIN=${URLSAFE_BRANCH_NAME}.pr.digital.ca.gov npm run build
           npx playwright install
           npm test

--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -44,6 +44,8 @@ jobs:
           mkdir dist
           npm ci --production
           DOMAIN=${URLSAFE_BRANCH_NAME}.pr.digital.ca.gov npm run build
+          npx playwright install
+          npm test
       - name: Write robots.txt
         run: |
           echo 'User-agent: *' > _site/robots.txt


### PR DESCRIPTION
Addresses issue #293 

Adding accessibility testing in PR builds will enable us to catch issues quickly, and avoid surprises at publish time.
It will slow down PR builds by a little over a minute.