### PR TITLE
Added break-all word-break styling for links in citations and footnotes.

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -270,3 +270,6 @@ cagov-pagination .cagov-pagination__item.cagov-pagination-current {
   /* margin: 0 0; */
   padding: 0 0;
 }
+ul.citation-list li a, ol.wp-block-footnotes li a {
+  word-break: break-all;
+}


### PR DESCRIPTION
Note: After this is merged, I will need to make a couple minor edits on the data-strategy-2024 report to prevent links from splitting in the middle of http.
