### PR TITLE
Smooth scroll to top when changing pages.

### DIFF
--- a/src/js/cagov-paginator.js
+++ b/src/js/cagov-paginator.js
@@ -15,11 +15,13 @@ class CAGovPaginator extends HTMLElement {
         console.log("number blocks",this.pagedBlocks.length);
         this.nbrPages = Math.ceil(this.pagedBlocks.length / this.perPage);
         this.currentPage = 1; // !!! pull from URL
+        this.priorPage = 1;
         var locationhash = location.hash;
         if (locationhash.startsWith('#page-')) {
             var cp = parseInt(locationhash.split('-')[1]);
             if (cp > 0 && cp <= this.nbrPages) {
                 this.currentPage = cp;
+                this.priorPage = cp;
                 console.log("Set current page to ",this.currentPage);
             }
         }
@@ -87,10 +89,13 @@ class CAGovPaginator extends HTMLElement {
         this.currentPage = parseInt(e.detail);
         this.drawCurrentPage();
         // smooth scroll to top
-        window.scrollTo({
-            top: 0,
-            behavior: 'smooth'
-        });
+        if (true) { // this.currentPage > this.priorPage going forward? scroll to top
+            window.scrollTo({
+                top: 0,
+                behavior: 'smooth'
+            });
+        }
+        this.priorPage = this.currentPage;
     }
 }
 

--- a/src/js/cagov-paginator.js
+++ b/src/js/cagov-paginator.js
@@ -80,17 +80,17 @@ class CAGovPaginator extends HTMLElement {
         location.hash = `#page-${this.currentPage}`;
         // console.log("location.hash",location.hash);
 
-        // smooth scroll to top
-        window.scrollTo({
-            top: 0,
-            behavior: 'smooth'
-        });
     }
 
     paginationHandler(e) {
         console.log("paginationHandler called", e);
         this.currentPage = parseInt(e.detail);
         this.drawCurrentPage();
+        // smooth scroll to top
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        });
     }
 }
 

--- a/src/js/cagov-paginator.js
+++ b/src/js/cagov-paginator.js
@@ -79,6 +79,12 @@ class CAGovPaginator extends HTMLElement {
 
         location.hash = `#page-${this.currentPage}`;
         // console.log("location.hash",location.hash);
+
+        // smooth scroll to top
+        window.scrollTo({
+            top: 0,
+            behavior: 'smooth'
+        });
     }
 
     paginationHandler(e) {


### PR DESCRIPTION
Smooth scroll to top when changing pages using the pagination widget.  Jeffrey's request.

https://app.asana.com/0/1208802063370031/1209079014287265/f

An open question is whether we should scroll-to-top when navigating to a prior page.  For now I'm scrolling to top regardless of the direction of travel.

