### PR TITLE
Styling fix to tweak alignment of engaged cal block on homepage.

### DIFF
--- a/src/css/index.scss
+++ b/src/css/index.scss
@@ -270,3 +270,15 @@ cagov-pagination .cagov-pagination__item.cagov-pagination-current {
   /* margin: 0 0; */
   padding: 0 0;
 }
+
+/* homepage patches */
+
+.cagov-aligned-group.homepage-engaged-group>.wp-block-group__inner-container {
+    align-items: start; /* was center */
+}
+
+figure.wp-block-image.size-full.cagov-align-left.homepage-engaged-figure {
+    margin-top: 11px;
+}
+
+


### PR DESCRIPTION
I added some custom classes in the wordpress markup to enable these tweaks.

BEFORE
![CleanShot 2025-03-14 at 10 22 42](https://github.com/user-attachments/assets/cea09853-ba51-42ec-a5f6-8dfd4deac4b4)

AFTER
![CleanShot 2025-03-14 at 10 23 28](https://github.com/user-attachments/assets/5ec237dd-dca3-4029-a640-d138e3723a9a)

