### PR TITLE
Fix site compilation bug

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -53,7 +53,7 @@ module.exports = function (eleventyConfig) {
         );
       }
       // Replace Wordpress media paths with correct 11ty output path.
-      const regexPattern = `http.+?pantheonsite\.io/wp-content/uploads/`;
+      const regexPattern = `http[^"']+?pantheonsite\.io/wp-content/uploads/`;
       content = content.replace(new RegExp(regexPattern, 'g'), `/${wordpressImagePath}/`);
     }
 


### PR DESCRIPTION
I found, when diagnosing a recurring build-error on the home page (triggered by adding an &lt;a&gt; tag around an image), that some markup was getting incorrectly mangled by the eleventy build script.  The culprit was the first period in the regular expression in these lines:

```
      // Replace Wordpress media paths with correct 11ty output path.
      const regexPattern = `http.+?pantheonsite\.io/wp-content/uploads/`;
      content = content.replace(new RegExp(regexPattern, 'g'), `/${wordpressImagePath}/`);
```
The above code appears to have been added Jan 3, 2024. The problem with it is that it even though it is set to non-greedy matching, it can trigger incorrect matches across _multiple tags on the same line_.  So for example if there is a single line that contains an &lt;a&gt; tag surrounding an &lt;img&gt; tag, everything from the "http" in the &lt;a&gt; tag to the "pantheonsite" in the &lt;img&gt; tag will get matched, and replaced, resulting in a new hybrid tag that starts with the &lt;a and ends with the properties of the img tag.  Fortunately, this corrupted markup failed the accessibility tester.

My patch replaces the first period with `[^'"]`, which prevents the match from spanning outside of the quotes, and across multiple tags on the same line.  This fixed the issue in my testing.  

Once this patch is applied, I can revert some of the markup on the homepage where I am having to explicitly use literal html code snippets to insure linefeeds are inserted.
