### PR TITLE
Eliminated three 3rd party plugins in favor of aws cli commands.

### DIFF
--- a/.github/workflows/deploy_dev_aws.yml
+++ b/.github/workflows/deploy_dev_aws.yml
@@ -25,24 +25,17 @@ jobs:
         run: |
           npm install
           npm run build
-      # Push built site files to S3 production bucket    
-      - name: Deploy to S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: 'development.digital.ca.gov'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-west-1'   # optional: defaults to us-east-1
-          SOURCE_DIR: ./_site # only move built directory
 
-      # Invalidate Cloudfront production distribution
-      - name: invalidate
-        uses: chetan/invalidate-cloudfront-action@v1.3
-        env:
-          DISTRIBUTION: 'E275WGCQ1RLRUJ'
-          PATHS: '/*'
-          AWS_REGION: 'us-west-1'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}             
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
+
+      - name: Deploy site to S3
+        run: aws s3 sync --follow-symlinks --delete ./_site s3://development.digital.ca.gov
+
+      - name: Invalidate Cloudfront cache
+        run: AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id  E275WGCQ1RLRUJ --paths "/*"
+

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -34,46 +34,26 @@ jobs:
           echo 'User-agent: *' > _site/robots.txt
           echo 'Allow: /' >> _site/robots.txt
           echo 'Sitemap: https://innovation.ca.gov/sitemap.xml' >> _site/robots.txt
-        # Push built site files to S3 production bucket    
-      - name: Deploy to S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
-        with:
-          args: --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: 'innovation.ca.gov'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-west-1'   # optional: defaults to us-east-1
-          SOURCE_DIR: ./_site # only move built directory
 
-      # Reset the cache-control headers on static assets on production S3 bucket
-      - name: Reset cache-control on static files
-        uses: prewk/s3-cp-action@v2
+      # Push built site files to S3 production bucket    
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
         with:
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: 'us-west-1'   # optional: defaults to us-east-1
-          source: './_site/fonts'
-          dest: 's3://innovation.ca.gov/fonts'
-          flags: --recursive --cache-control max-age=15552000
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
 
-      # Reset the cache-control headers on static assets on production S3 bucket
-      - name: Reset cache-control on static files
-        uses: prewk/s3-cp-action@v2
-        with:
-          aws_access_key_id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws_region: 'us-west-1'   # optional: defaults to us-east-1
-          source: './_site/img'
-          dest: 's3://innovation.ca.gov/img'
-          flags: --recursive --cache-control max-age=15552000
+      - name: Deploy site to S3
+        run: aws s3 sync --follow-symlinks --delete ./_site s3://innovation.ca.gov
 
-      # Invalidate Cloudfront production distribution
-      - name: invalidate
-        uses: chetan/invalidate-cloudfront-action@v1.3
-        env:
-          DISTRIBUTION: 'EB84S7ZI5YNKP'
-          PATHS: '/*'
-          AWS_REGION: 'us-west-1'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}                       
+      - name: Reset cache-control on fonts
+        run: aws s3 cp ./_site/fonts s3://innovation.ca.gov/fonts --recursive --metadata-directive REPLACE --cache-control "max-age=15552000" --content-type "auto-detect"
+
+      - name: Reset cache-control on images
+        run: aws s3 cp ./_site/img s3://innovation.ca.gov/img --recursive --metadata-directive REPLACE --cache-control "max-age=15552000" --content-type "auto-detect"
+
+      - name: Invalidate Cloudfront cache
+        run: AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id  EB84S7ZI5YNKP --paths "/*"
+
+
+

--- a/.github/workflows/eleventy_build_pr.yml
+++ b/.github/workflows/eleventy_build_pr.yml
@@ -51,25 +51,20 @@ jobs:
           echo 'User-agent: *' > _site/robots.txt
           echo 'Disallow: /' >> _site/robots.txt
           echo 'Sitemap: https://innovation.ca.gov/sitemap.xml' >> _site/robots.txt
-      - name: Deploy to S3
-        uses: jakejarvis/s3-sync-action@v0.5.1
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@master
         with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          AWS_S3_BUCKET: 'pr.digital.ca.gov'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_REGION: 'us-west-1'   # optional: defaults to us-east-1
-          SOURCE_DIR: ./_site # only move built directory
-          DEST_DIR: pr/${URLSAFE_BRANCH_NAME}
-      - name: Invalidate CloudFront cache
-        uses: chetan/invalidate-cloudfront-action@v1.3
-        env:
-          DISTRIBUTION: 'E1OXUPLBNPS6DU'
-          PATHS: '/*'
-          AWS_REGION: 'us-west-1'
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-west-1
+
+      - name: Deploy site to S3
+        run: aws s3 sync --acl public-read --follow-symlinks --delete ./_site s3://pr.digital.ca.gov/pr/${URLSAFE_BRANCH_NAME}
+
+      - name: Invalidate Cloudfront cache
+        run: AWS_MAX_ATTEMPTS=10 aws cloudfront create-invalidation --distribution-id  E1OXUPLBNPS6DU --paths "/*"
+
       - name: Post URL to PR
         uses: mshick/add-pr-comment@v2.8.2
         with:


### PR DESCRIPTION
Reduce reliance on 3rd party plugins for simple AWS tasks, for greater resiliency and reduced code size :

Eliminates use of 
* jakejarvis/s3-sync-action,
* prewk/s3-cp-action@v2, and 
* chetan/invalidate-cloudfront-action, 

...and instead runs the underlying aws cli commands directly, a feature supported by github.

Simplifies the build scripts (reduced line count), eliminating redundancy in credentials and region params.
